### PR TITLE
Composer won't selfupdate without a $HOME or $COMPOSER_HOME  set

### DIFF
--- a/composer/init.sls
+++ b/composer/init.sls
@@ -6,12 +6,14 @@ composer-install-pkg:
     - name: {{ composer.lookup.apt }}
     - dist: trusty
   pkg.installed:
-    - name: {{ composer.lookup.pkgname }} 
+    - name: {{ composer.lookup.pkgname }}
     - refresh: True
     - force_yes: True
     - require:
-      - pkgrepo: composer-install-pkg 
+      - pkgrepo: composer-install-pkg
   cmd.run:
     - name: "composer self-update"
+    - env:
+      - HOME: '/root'
     - require:
       - pkg: composer-install-pkg


### PR DESCRIPTION
The commit message expanded the env vars.. I did't escape them. Oops.

Anyway, the current salt version doesn't work with cmd.run for composer because composer needs a $HOME.
